### PR TITLE
Support searching for Java archive files inside RPM

### DIFF
--- a/internal/file/rpm_file_traversal.go
+++ b/internal/file/rpm_file_traversal.go
@@ -1,0 +1,55 @@
+package file
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/sassoftware/go-rpmutils"
+)
+
+// ExtractGlobsFromRPMToUniqueTempFile extracts paths matching the given globs within the given RPM to a temporary directory, returning file openers for each file extracted.
+func ExtractGlobsFromRPMToUniqueTempFile(rpmPath, dir string, globs ...string) (map[string]Opener, error) {
+	results := make(map[string]Opener)
+	var err error
+	// don't allow for full traversal, only select traversal from given paths
+	if len(globs) == 0 {
+		return results, nil
+	}
+	f, err := os.Open(rpmPath)
+	if err != nil {
+		return results, nil
+	}
+	defer f.Close()
+	rpm, err := rpmutils.ReadRpm(f)
+	var files int
+	payload, err := rpm.PayloadReaderExtended()
+	for {
+		file, err := payload.Next()
+		if err == io.EOF {
+			break
+		}
+		if !matchesAnyGlob(file.Name(), globs...) {
+			continue
+		}
+
+		// we have a file we want to extract....
+		tempfilePrefix := filepath.Base(filepath.Clean(file.Name())) + "-"
+		tempFile, err := os.CreateTemp(dir, tempfilePrefix)
+		if err != nil {
+			continue
+		}
+		// we shouldn't try and keep the tempfile open as the returned result may have several files, which takes up
+		// resources (leading to "too many open files"). Instead we'll return a file opener to the caller which
+		// provides a ReadCloser. It is up to the caller to handle closing the file explicitly.
+		if err := safeCopy(tempFile, payload); err != nil {
+			tempFile.Close()
+			continue
+		}
+		results[file.Name()] = Opener{path: tempFile.Name()}
+		tempFile.Close()
+		files++
+	}
+
+	return results, nil
+}

--- a/syft/formats/common/spdxhelpers/external_ref.go
+++ b/syft/formats/common/spdxhelpers/external_ref.go
@@ -29,6 +29,8 @@ const (
 	PurlExternalRefType ExternalRefType = "purl"
 	// These point to objects present in the Software Heritage archive by the means of SoftWare Heritage persistent Identifiers (SWHID)
 	SwhExternalRefType ExternalRefType = "swh"
+	// BazelLabelExternalRefType point to label used by Bazel for building
+	BazelLabelExternalRefType ExternalRefType = "LocationRef-pkgmgr-bazel-label"
 )
 
 type ExternalRef struct {

--- a/syft/formats/common/spdxhelpers/external_refs.go
+++ b/syft/formats/common/spdxhelpers/external_refs.go
@@ -23,5 +23,23 @@ func ExternalRefs(p pkg.Package) (externalRefs []ExternalRef) {
 		})
 	}
 
+	switch meta := p.Metadata.(type) {
+	// Java packages may specify the bazel label used to build it
+	case pkg.JavaMetadata:
+		if meta.Manifest != nil {
+			if _, createdByFound := meta.Manifest.Main["Created-By"]; createdByFound {
+				if meta.Manifest.Main["Created-By"] == "bazel" {
+					if _, targetLabelFound := meta.Manifest.Main["Target-Label"]; targetLabelFound {
+						externalRefs = append(externalRefs, ExternalRef{
+							ReferenceCategory: OtherReferenceCategory,
+							ReferenceLocator:  meta.Manifest.Main["Target-Label"],
+							ReferenceType:     BazelLabelExternalRefType,
+						})
+					}
+				}
+			}
+		}
+	}
+
 	return externalRefs
 }

--- a/syft/pkg/cataloger/java/cataloger.go
+++ b/syft/pkg/cataloger/java/cataloger.go
@@ -20,6 +20,8 @@ func NewJavaCataloger(cfg Config) *generic.Cataloger {
 	if cfg.SearchUnindexedArchives {
 		// java archives wrapped within tar files
 		c.WithParserByGlobs(parseTarWrappedJavaArchive, genericTarGlobs...)
+		// java archives wrapped within rpm files
+		c.WithParserByGlobs(parseRPMJavaArchive, genericRpmGlobs...)
 	}
 	return c
 }

--- a/syft/pkg/cataloger/java/rpm_parser.go
+++ b/syft/pkg/cataloger/java/rpm_parser.go
@@ -1,0 +1,77 @@
+package java
+
+import (
+	"fmt"
+
+	"github.com/anchore/syft/internal/file"
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/generic"
+	"github.com/anchore/syft/syft/pkg/cataloger/rpm"
+	"github.com/anchore/syft/syft/source"
+)
+
+var genericRpmGlobs = []string{
+	"**/*.rpm",
+}
+
+// TODO: when the generic archive cataloger is implemented, this should be removed (https://github.com/anchore/syft/issues/246)
+
+// parseRPMJavaArchive is a parser function for java archive contents contained within rpm files.
+func parseRPMJavaArchive(
+	resolver source.FileResolver, _ *generic.Environment, reader source.LocationReadCloser,
+) ([]pkg.Package, []artifact.Relationship, error) {
+
+	contentPath, archivePath, cleanupFn, err := saveArchiveToTmp(reader.AccessPath(), reader)
+	// note: even on error, we should always run cleanup functions
+	defer cleanupFn()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_cataloger := rpm.NewFileCataloger()
+	var rpmPackages []pkg.Package
+	rpmPackages, _, err = _cataloger.Catalog(resolver)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to read files from java archive: %w", err)
+	}
+
+	var packages []pkg.Package
+	var relationships []artifact.Relationship
+	for _, rpmPackage := range rpmPackages {
+		_packages, _relationships, err := discoverPkgsFromRPM(reader.Location, archivePath, contentPath, &rpmPackage)
+		if err == nil {
+			packages = append(packages, _packages...)
+			relationships = append(relationships, _relationships...)
+		}
+	}
+	return packages, relationships, nil
+}
+
+func discoverPkgsFromRPM(
+	location source.Location, archivePath, contentPath string, parentPkg *pkg.Package,
+) ([]pkg.Package, []artifact.Relationship, error) {
+	openers, err := file.ExtractGlobsFromRPMToUniqueTempFile(archivePath, contentPath, archiveFormatGlobs...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to extract files from tar: %w", err)
+	}
+
+	var relationships []artifact.Relationship
+	_packages, _, err := discoverPkgsFromOpeners(location, openers, parentPkg)
+	if err == nil {
+		for index := range _packages {
+			id := _packages[index].ID()
+			if id == "" {
+				_packages[index].SetID()
+			}
+			_relationship := artifact.Relationship{
+				From: *parentPkg,
+				To:   _packages[index],
+				Type: artifact.ContainsRelationship,
+			}
+			relationships = append(relationships, _relationship)
+		}
+
+	}
+	return _packages, relationships, err
+}

--- a/syft/pkg/cataloger/search_config.go
+++ b/syft/pkg/cataloger/search_config.go
@@ -11,7 +11,7 @@ type SearchConfig struct {
 func DefaultSearchConfig() SearchConfig {
 	return SearchConfig{
 		IncludeIndexedArchives:   true,
-		IncludeUnindexedArchives: false,
+		IncludeUnindexedArchives: true,
 		Scope:                    source.SquashedScope,
 	}
 }


### PR DESCRIPTION
Support searching for Java archive files inside RPM and add a relationship of the RPM being the parent package of the Java file Enable searching unindexed archives like tar.gz and RPM files Extract Bazel label from Java manifest file and convert it SPDX external reference of Bazel package manager