### PR TITLE
Disable post hook used for Darwin builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,11 +39,6 @@ builds:
       - arm64
     mod_timestamp: *build-timestamp
     ldflags: *build-ldflags
-    hooks:
-      post:
-        - cmd: .tool/quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }} -vv
-          env:
-            - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
 
   - id: windows-build
     dir: ./cmd/syft


### PR DESCRIPTION
Disable post hook used for Darwin builds as it is unsupported for Lineaje currently