### PR TITLE
Persist Image Details as CycloneDX properties

### DIFF
--- a/syft/source/image_metadata.go
+++ b/syft/source/image_metadata.go
@@ -21,7 +21,7 @@ type ImageMetadata struct {
 
 // LayerMetadata represents all static metadata that defines what a container image layer is.
 type LayerMetadata struct {
-	MediaType string `json:"mediaType"`
-	Digest    string `json:"digest"`
-	Size      int64  `json:"size"`
+	MediaType string `json:"mediaType" cyclonedx:"mediaType"`
+	Digest    string `json:"digest" cyclonedx:"digest"`
+	Size      int64  `json:"size" cyclonedx:"size"`
 }


### PR DESCRIPTION
Persist Image Details such as User Input, Image ID, Manifest Digest, Layer details, Repo Digest, Config, Manifest information, Architecture, OS etc as CycloneDX properties so that they can be converted back to a syft json when convert is used