### PR TITLE
Update support for opkg (OpenWrt) packages in syft

### DIFF
--- a/syft/format/internal/cyclonedxutil/helpers/description.go
+++ b/syft/format/internal/cyclonedxutil/helpers/description.go
@@ -9,6 +9,8 @@ func encodeDescription(p pkg.Package) string {
 			return metadata.Description
 		case pkg.NpmPackage:
 			return metadata.Description
+		case pkg.DpkgDBEntry:
+			return metadata.Description
 		}
 	}
 	return ""

--- a/syft/linux/identify_release.go
+++ b/syft/linux/identify_release.go
@@ -46,11 +46,12 @@ var identityFiles = []parseEntry{
 	},
 	// /////////////////////////////////////////////////////////////////////////////////////////////////////
 	// IMPORTANT! checking busybox must be last since other distros contain the busybox binary
-	{
-		// check for busybox
-		path: "/bin/busybox",
-		fn:   parseBusyBox,
-	},
+	// Commented as this is not a recognized distribution string
+	// {
+	// 	// check for busybox
+	// 	path: "/bin/busybox",
+	// 	fn:   parseBusyBox,
+	// },
 	// /////////////////////////////////////////////////////////////////////////////////////////////////////
 }
 

--- a/syft/pkg/cataloger/debian/cataloger.go
+++ b/syft/pkg/cataloger/debian/cataloger.go
@@ -14,6 +14,6 @@ func NewDBCataloger() pkg.Cataloger {
 	return generic.NewCataloger("dpkg-db-cataloger").
 		// note: these globs have been intentionally split up in order to improve search performance,
 		// please do NOT combine into: "**/var/lib/dpkg/{status,status.d/*}"
-		WithParserByGlobs(parseDpkgDB, "**/var/lib/dpkg/status", "**/var/lib/dpkg/status.d/*", "**/lib/opkg/info/*.control", "**/lib/opkg/status").
+		WithParserByGlobs(parseDpkgDB, "**/var/lib/dpkg/status", "**/var/lib/dpkg/status.d/*", "**/lib/opkg/status").
 		WithProcessors(dependency.Processor(dbEntryDependencySpecifier))
 }

--- a/syft/pkg/cataloger/debian/parse_dpkg_db.go
+++ b/syft/pkg/cataloger/debian/parse_dpkg_db.go
@@ -79,6 +79,7 @@ type dpkgExtractedMetadata struct {
 	Provides      string `mapstructure:"Provides"`
 	Depends       string `mapstructure:"Depends"`
 	PreDepends    string `mapstructure:"PreDepends"` // note: original doc is Pre-Depends
+	License       string `mapstructure:"License"`
 }
 
 // parseDpkgStatusEntry returns an individual Dpkg entry, or returns errEndOfPackages if there are no more packages to parse from the reader.
@@ -138,6 +139,52 @@ func parseDpkgStatusEntry(reader *bufio.Reader) (*pkg.DpkgDBEntry, error) {
 	}
 
 	return &entry, retErr
+}
+
+// parseDpkgControlEntry returns an individual Dpkg entry from the reader.
+// It is similar to parseDpkgStatusEntry but does not return errEndOfPackages if there are no more packages to parse from the reader.
+func parseDpkgControlEntry(reader *bufio.Reader) (*pkg.DpkgDBEntry, error) {
+	dpkgFields, err := extractAllFields(reader)
+	if err != nil {
+		if !errors.Is(err, errEndOfPackages) {
+			return nil, err
+		}
+		if len(dpkgFields) == 0 {
+			return nil, err
+		}
+	}
+
+	raw := dpkgExtractedMetadata{}
+	err = mapstructure.Decode(dpkgFields, &raw)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceName, sourceVersion := extractSourceVersion(raw.Source)
+	if sourceVersion != "" {
+		raw.SourceVersion = sourceVersion
+		raw.Source = sourceName
+	}
+
+	if raw.Package == "" {
+		return nil, nil
+	}
+
+	entry := pkg.DpkgDBEntry{
+		Package:       raw.Package,
+		Source:        raw.Source,
+		Version:       raw.Version,
+		SourceVersion: raw.SourceVersion,
+		Architecture:  raw.Architecture,
+		Maintainer:    raw.Maintainer,
+		License:       raw.License,
+		InstalledSize: raw.InstalledSize,
+		Description:   raw.Description,
+		Provides:      splitPkgList(raw.Provides),
+		Depends:       splitPkgList(raw.Depends),
+		PreDepends:    splitPkgList(raw.PreDepends),
+	}
+	return &entry, nil
 }
 
 func splitPkgList(pkgList string) (ret []string) {

--- a/syft/pkg/dpkg.go
+++ b/syft/pkg/dpkg.go
@@ -36,11 +36,14 @@ type DpkgDBEntry struct {
 	// address inside angle brackets <> (in RFC822 format).
 	Maintainer string `json:"maintainer"`
 
+	// License is present in the control file and not in the status file. This is only read to populate the parent license structure
+	License string `json:"-"`
+
 	InstalledSize int `json:"installedSize" cyclonedx:"installedSize"`
 
 	// Description contains a description of the binary package, consisting of two parts, the synopsis or the short
 	// description, and the long description (in a multiline format).
-	Description string `hash:"ignore" json:"-"`
+	Description string `hash:"ignore" json:"description,omitempty"`
 
 	// Provides is a virtual package that is provided by one or more packages. A virtual package is one which appears
 	// in the Provides control field of another package. The effect is as if the package(s) which provide a particular


### PR DESCRIPTION
Update support for opkg (OpenWrt) packages in syft to,
- Create opkg OpenWrt PURLs based on the location of the package file. Extract Description, License, and Source from the control file of opkg files and persist them in the package metadata
- Save Description discovered for all Debian Packages
- Process only status file for opkg (OpenWRT package manager). Processing control files in addition to the status file generates duplicate packages
- Read license from Debian control files. Persist Description read from Debian control file in the package metadata for reuse
- Add support to read individual Debian control files required to extract license and description data from opkg packages
- Disable detection of BusyBox as a distribution ID as it is unknown