### PR TITLE
Ignore file indexing error and proceed

### DIFF
--- a/syft/internal/fileresolver/directory_indexer.go
+++ b/syft/internal/fileresolver/directory_indexer.go
@@ -87,7 +87,8 @@ loop:
 
 		additionalRoots, err := indexer(currentPath, stager)
 		if err != nil {
-			return fmt.Errorf("unable to index filesystem path=%q: %w", currentPath, err)
+			log.WithFields("path", currentPath).Warnf("unable to index filesystem path=%q: %w", currentPath, err)
+			continue
 		}
 
 		for _, newRoot := range additionalRoots {


### PR DESCRIPTION
Ignore file indexing error and proceed. This scenario hits very frequently with processing contents of partitions in an AMI.

# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

<!-- If this completes an issue, please include: -->

- Fixes #

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
