### PR TITLE
Set CocoaPods subspec as PURL subpath

### DIFF
--- a/syft/pkg/cataloger/swift/package.go
+++ b/syft/pkg/cataloger/swift/package.go
@@ -46,6 +46,14 @@ func newCocoaPodsPackage(name, version, hash string, locations ...file.Location)
 
 func cocoaPodsPackageURL(name, version string) string {
 	var qualifiers packageurl.Qualifiers
+	var subPath string
+	if strings.Contains(name, "/") {
+		nameParts := strings.Split(name, "/")
+		name = nameParts[0]
+		if len(nameParts) > 1 {
+			subPath = strings.Join(nameParts[1:], "/")
+		}
+	}
 
 	return packageurl.NewPackageURL(
 		packageurl.TypeCocoapods,
@@ -53,7 +61,7 @@ func cocoaPodsPackageURL(name, version string) string {
 		name,
 		version,
 		qualifiers,
-		"",
+		subPath,
 	).ToString()
 }
 


### PR DESCRIPTION
Set CocoaPods subspec as PURL subpath as per the specification

# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

<!-- If this completes an issue, please include: -->

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
