### PR TITLE
Create dependencies from CocoaPods Podfile.lock

### DIFF
--- a/syft/pkg/cataloger/swift/dependency.go
+++ b/syft/pkg/cataloger/swift/dependency.go
@@ -1,0 +1,32 @@
+package swift
+
+import (
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/dependency"
+)
+
+func podfileLockDependencySpecifier(p pkg.Package) dependency.Specification {
+	meta, ok := p.Metadata.(pkg.CocoaPodfileLockEntry)
+	if !ok {
+		log.Tracef("cataloger failed to extract podfile lock metadata for package %+v", p.Name)
+		return dependency.Specification{}
+	}
+
+	// this package reference always includes the package name and no extras
+	provides := []string{p.Name}
+
+	var requires []string
+	// add required dependencies
+	for _, dep := range meta.Dependencies {
+		// we always have the base package requirement without any extras to get base dependencies
+		requires = append(requires, dep)
+	}
+
+	return dependency.Specification{
+		ProvidesRequires: dependency.ProvidesRequires{
+			Provides: provides,
+			Requires: requires,
+		},
+	}
+}

--- a/syft/pkg/cataloger/swift/package.go
+++ b/syft/pkg/cataloger/swift/package.go
@@ -26,7 +26,7 @@ func newSwiftPackageManagerPackage(name, version, sourceURL, revision string, lo
 	return p
 }
 
-func newCocoaPodsPackage(name, version, hash string, locations ...file.Location) pkg.Package {
+func newCocoaPodsPackage(name, version, hash string, deps []string, locations ...file.Location) pkg.Package {
 	p := pkg.Package{
 		Name:      name,
 		Version:   version,
@@ -36,6 +36,7 @@ func newCocoaPodsPackage(name, version, hash string, locations ...file.Location)
 		Language:  pkg.Swift,
 		Metadata: pkg.CocoaPodfileLockEntry{
 			Checksum: hash,
+			Dependencies: deps,
 		},
 	}
 

--- a/syft/pkg/cocoapods.go
+++ b/syft/pkg/cocoapods.go
@@ -3,4 +3,5 @@ package pkg
 // CocoaPodfileLockEntry represents a single entry from the "Pods" section of a Podfile.lock file.
 type CocoaPodfileLockEntry struct {
 	Checksum string `mapstructure:"checksum" json:"checksum"`
+	Dependencies []string `mapstructure:"dependencies" json:"dependencies"`
 }


### PR DESCRIPTION
Create dependencies from CocoaPods Podfile.lock by considering CocoaPods subspec as dependencies of the parent CocoaPods component

# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

<!-- If this completes an issue, please include: -->

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
