### PR TITLE
Add AI Model Cataloger based on config.json

### DIFF
--- a/internal/task/package_tasks.go
+++ b/internal/task/package_tasks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/javascript"
 	"github.com/anchore/syft/syft/pkg/cataloger/kernel"
 	"github.com/anchore/syft/syft/pkg/cataloger/lua"
+	"github.com/anchore/syft/syft/pkg/cataloger/modelartifact"
 	"github.com/anchore/syft/syft/pkg/cataloger/nix"
 	"github.com/anchore/syft/syft/pkg/cataloger/ocaml"
 	"github.com/anchore/syft/syft/pkg/cataloger/php"
@@ -159,5 +160,6 @@ func DefaultPackageTaskFactories() Factories {
 		newSimplePackageTaskFactory(bitnamiSbomCataloger.NewCataloger, "bitnami", pkgcataloging.InstalledTag, pkgcataloging.ImageTag),
 		newSimplePackageTaskFactory(wordpress.NewWordpressPluginCataloger, pkgcataloging.DirectoryTag, pkgcataloging.ImageTag, "wordpress"),
 		newSimplePackageTaskFactory(terraform.NewLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "terraform"),
+		newSimplePackageTaskFactory(modelartifact.NewCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.ImageTag, "model", "ml", "ai"),
 	}
 }

--- a/syft/pkg/cataloger/modelartifact/cataloger.go
+++ b/syft/pkg/cataloger/modelartifact/cataloger.go
@@ -1,0 +1,15 @@
+/*
+Package modelartifact provides a concrete Cataloger implementation for detecting machine learning model artifacts.
+*/
+package modelartifact
+
+import (
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/generic"
+)
+
+// NewCataloger returns a new cataloger for model artifacts based on config.json files
+func NewCataloger() pkg.Cataloger {
+	return generic.NewCataloger("model-artifact-cataloger").
+		WithParserByGlobs(parseConfigJSON, "**/config.json")
+}

--- a/syft/pkg/cataloger/modelartifact/parse_config.go
+++ b/syft/pkg/cataloger/modelartifact/parse_config.go
@@ -1,0 +1,276 @@
+package modelartifact
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/generic"
+	"gopkg.in/yaml.v3"
+)
+
+// declare enum with modelartifactory types
+const (
+	HuggingFace = "huggingface"
+	LocalModel  = "local_model"
+)
+
+// parseConfigJSON parses a config.json file and returns discovered model artifacts
+func parseConfigJSON(_ context.Context, resolver file.Resolver, env *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
+	var config map[string]interface{}
+
+	decoder := json.NewDecoder(reader)
+	if err := decoder.Decode(&config); err != nil {
+		return nil, nil, nil // Return empty results for invalid JSON
+	}
+
+	// Check if this is a model config file
+	if !isModelConfig(config) {
+		return nil, nil, nil
+	}
+
+	// Get the directory containing the config.json file using the absolute path
+	repoDirectory := filepath.Dir(string(reader.Location.Reference().RealPath))
+
+	// Extract model information
+	modelInfo := &pkg.ModelArtifact{
+		ConfigPath: reader.Location.RealPath,
+	}
+
+	// Extract _name_or_path if present
+	if nameOrPath, ok := config["name_or_path"].(string); ok {
+		modelInfo.Name = nameOrPath
+	}
+
+	// Extract model_type if present
+	if modelType, ok := config["model_type"].(string); ok {
+		modelInfo.ModelType = modelType
+	}
+
+	// Extract architectures if present
+	if architectures, ok := config["architectures"].([]interface{}); ok {
+		var archStrings []string
+		for _, arch := range architectures {
+			if archStr, ok := arch.(string); ok {
+				archStrings = append(archStrings, archStr)
+			}
+		}
+		modelInfo.Architectures = archStrings
+	}
+
+	// Check for Git repository and extract remote URL
+	gitRemoteURL := getGitRemoteURL(repoDirectory)
+	var modelName, version, purl string
+
+	if gitRemoteURL != "" && strings.Contains(gitRemoteURL, "huggingface.co") {
+		// Extract model name and version from HuggingFace URL
+		modelName, version = parseHuggingFaceURL(gitRemoteURL)
+		purl = getAIModelPurl(HuggingFace, modelName, version)
+	} else {
+		// Local model - use name from config if available, otherwise use directory name
+		if modelInfo.Name != "" {
+			modelName = modelInfo.Name
+		} else {
+			dirName := filepath.Base(repoDirectory)
+			if dirName == "" || dirName == "." {
+				dirName = "unknown-model"
+			}
+			modelName = dirName
+		}
+		modelInfo.Artifactory = LocalModel
+		version = "UNKNOWN"
+		purl = getAIModelPurl(LocalModel, modelName, version)
+	}
+
+	// Create the main package
+	mainPkg := pkg.Package{
+		Name:      modelName,
+		Version:   version,
+		Type:      pkg.ModelArtifactPkg,
+		Locations: file.NewLocationSet(reader.Location),
+		PURL:      purl,
+		Metadata:  *modelInfo,
+	}
+
+	packages := []pkg.Package{mainPkg}
+	relationships := []artifact.Relationship{}
+
+	// Parse README.md for base models
+	baseModels := parseBaseModelsFromReadme(resolver, repoDirectory)
+	for _, baseModel := range baseModels {
+		// As basemodel extraction is done by Model card specification provided by hugging face, the basemodel's artifactory is set as huggingface
+		baseModelPkg := createBaseModelPackage(HuggingFace, baseModel, "", reader.Location)
+		packages = append(packages, baseModelPkg)
+		relationships = append(relationships, artifact.Relationship{
+			From: mainPkg,
+			To:   baseModelPkg,
+			Type: artifact.ContainsRelationship,
+		})
+	}
+
+	return packages, relationships, nil
+}
+
+// isModelConfig checks if the config contains model-specific fields
+// config json specifications: https://huggingface.co/docs/transformers/main_classes/configuration
+func isModelConfig(config map[string]interface{}) bool {
+	// Check for common model config indicators
+	if _, hasNameOrPath := config["name_or_path"]; hasNameOrPath {
+		return true
+	}
+	if _, hasModelType := config["model_type"]; hasModelType {
+		return true
+	}
+	if _, hasArchitectures := config["architectures"]; hasArchitectures {
+		return true
+	}
+	return false
+}
+
+// getGitRemoteURL checks if there's a .git directory and extracts the remote URL
+func getGitRemoteURL(repoDirectory string) string {
+	gitDir := filepath.Join(repoDirectory, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return ""
+	}
+
+	// Try to read the remote URL from .git/config
+	configPath := filepath.Join(gitDir, "config")
+	if configContent, err := os.ReadFile(configPath); err == nil {
+		// Look for remote "origin" URL
+		remotePattern := regexp.MustCompile(`\[remote "origin"\][\s\S]*?url = (.+)`)
+		if matches := remotePattern.FindSubmatch(configContent); len(matches) > 1 {
+			return strings.TrimSpace(string(matches[1]))
+		}
+	}
+
+	return ""
+}
+
+// parseHuggingFaceURL extracts model name and version from HuggingFace URL
+func parseHuggingFaceURL(gitURL string) (modelname string, branch string) {
+	// Remove .git suffix if present
+	gitURL = strings.TrimSuffix(gitURL, ".git")
+
+	// Extract the model path from URL like https://huggingface.co/zai-org/GLM-4.5V
+	urlPattern := regexp.MustCompile(`https://huggingface\.co/(.+)`)
+	if matches := urlPattern.FindStringSubmatch(gitURL); len(matches) > 1 {
+		modelPath := matches[1]
+		// For every new version of the Model hugging face have different repository
+		// Even though by context new models versions are successors of old versions
+		// they are completly seperate artifact and may not technically related to older version
+		// e.g. llama3 is successor of llama2 but they are completly seperate artifact trained of different parameter counts
+		// 1. meta-llama/Llama-3.2-3B-Instruct
+		// 2. meta-llama/Meta-Llama-3-8B-Instruct
+
+		// Thus, the version of the model is hardcoded to main, as it refers to latest commit in huggingface repository.
+		return modelPath, "main"
+	}
+
+	return "unknown", "unknown"
+}
+
+// parseBaseModelsFromReadme reads README.md and extracts base_model information
+// For huggingface repo, Model card is Markdown readme file with YAML Section at the top
+// Specification: https://huggingface.co/docs/hub/en/model-cards#model-card-metadata
+func parseBaseModelsFromReadme(resolver file.Resolver, repoDirectory string) (baseModels []string) {
+	if resolver == nil {
+		return baseModels
+	}
+	readmePath := filepath.Join(repoDirectory, "README.md")
+	readmeLocations, err := resolver.FilesByPath(readmePath)
+	if err != nil || len(readmeLocations) == 0 {
+		return baseModels
+	}
+	readmeLocation := readmeLocations[0]
+	readmeReader, err := resolver.FileContentsByLocation(readmeLocation)
+	if err != nil {
+		return nil
+	}
+	defer readmeReader.Close()
+
+	fileContent, err := io.ReadAll(readmeReader)
+	if err != nil {
+		return baseModels
+	}
+	// Look for YAML section between --- markers
+	yamlPattern := regexp.MustCompile(`(?s)---\s*(.*?)\s*---`)
+	if matches := yamlPattern.FindSubmatch(fileContent); len(matches) > 1 {
+		var metadata map[string]interface{}
+		if err := yaml.Unmarshal(matches[1], &metadata); err == nil {
+			if baseModel, ok := metadata["base_model"]; ok {
+				switch v := baseModel.(type) {
+				case string:
+					baseModels = append(baseModels, strings.ToLower(v))
+				case []interface{}:
+					for _, model := range v {
+						if modelStr, ok := model.(string); ok {
+							baseModels = append(baseModels, strings.ToLower(modelStr))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return baseModels
+}
+
+// createBaseModelPackage creates a package for a base model
+func createBaseModelPackage(artifactory string, baseModel string, version string, location file.Location) pkg.Package {
+	purl := getAIModelPurl(artifactory, baseModel, version)
+	return pkg.Package{
+		Name:      baseModel,
+		Version:   version,
+		Type:      pkg.ModelArtifactPkg,
+		Locations: file.NewLocationSet(location),
+		PURL:      purl,
+		Metadata: pkg.ModelArtifact{
+			Name:        baseModel,
+			Artifactory: artifactory,
+		},
+	}
+}
+
+// getModelName extracts a clean model name from the model artifact
+func getModelName(modelInfo *pkg.ModelArtifact) string {
+	if modelInfo.Name != "" {
+		// If it's a path-like name (e.g., "microsoft/DialoGPT-medium"), extract the last part
+		if strings.Contains(modelInfo.Name, "/") {
+			parts := strings.Split(modelInfo.Name, "/")
+			return parts[len(parts)-1]
+		}
+		return modelInfo.Name
+	}
+
+	// Fallback to directory name from config path
+	if modelInfo.ConfigPath != "" {
+		dir := filepath.Dir(modelInfo.ConfigPath)
+		return filepath.Base(dir)
+	}
+
+	// Final fallback
+	return "unknown-model"
+}
+
+// getAIModelPurl returns the PURL for an AI model
+func getAIModelPurl(modelartifactory string, modelName string, version string) string {
+	// The PURL specification for AI models is pkg:aimodel/<modelartifactory>/<modelowner>/<modelname>@<version>
+	// Model Artifactory can be huggingface, local_model, tensorflowhub etc. Thus can locate unique weights and tokenizers used for the model
+	// <modelowner>/<modelname> uniquely identify the model in artifactory
+	// <version> is the artifactories version for the model like branch name or commit id for huggingface.
+
+	if modelartifactory == HuggingFace && version == "" {
+		// Huggingface models have default branch as "main"
+		version = "main"
+	}
+	return fmt.Sprintf("pkg:aimodel/%s/%s@%s", modelartifactory, modelName, version)
+}

--- a/syft/pkg/cataloger/modelartifact/parse_config.go
+++ b/syft/pkg/cataloger/modelartifact/parse_config.go
@@ -20,7 +20,7 @@ import (
 // declare enum with modelartifactory types
 const (
 	HuggingFace = "huggingface"
-	LocalModel  = "local_model"
+	CustomModel = "custommodel"
 )
 
 // parseConfigJSON parses a config.json file and returns discovered model artifacts
@@ -85,9 +85,9 @@ func parseConfigJSON(_ context.Context, resolver file.Resolver, env *generic.Env
 			}
 			modelName = dirName
 		}
-		modelInfo.Artifactory = LocalModel
+		modelInfo.Artifactory = CustomModel
 		version = "UNKNOWN"
-		purl = getAIModelPurl(LocalModel, modelName, version)
+		purl = getAIModelPurl(CustomModel, modelName, version)
 	}
 
 	// Create the main package

--- a/syft/pkg/cataloger/modelartifact/parse_config_test.go
+++ b/syft/pkg/cataloger/modelartifact/parse_config_test.go
@@ -22,17 +22,17 @@ func TestParseConfigJSON(t *testing.T) {
 		expectedType  string
 		shouldDetect  bool
 	}{
-		// {
-		// 	name: "valid model config with _name_or_path",
-		// 	configContent: `{
-		// 		"name_or_path": "microsoft/DialoGPT-medium",
-		// 		"model_type": "gpt2",
-		// 		"architectures": ["GPT2LMHeadModel"]
-		// 	}`,
-		// 	expectedName: "microsoft/DialoGPT-medium",
-		// 	expectedType: "gpt2",
-		// 	shouldDetect: true,
-		// },
+		{
+			name: "valid model config with _name_or_path",
+			configContent: `{
+				"name_or_path": "microsoft/DialoGPT-medium",
+				"model_type": "gpt2",
+				"architectures": ["GPT2LMHeadModel"]
+			}`,
+			expectedName: "microsoft/DialoGPT-medium",
+			expectedType: "gpt2",
+			shouldDetect: true,
+		},
 		{
 			name: "valid model config with model_type only",
 			configContent: `{

--- a/syft/pkg/cataloger/modelartifact/parse_config_test.go
+++ b/syft/pkg/cataloger/modelartifact/parse_config_test.go
@@ -1,0 +1,191 @@
+package modelartifact
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	anchorefile "github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/generic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConfigJSON(t *testing.T) {
+	tests := []struct {
+		name          string
+		configContent string
+		expectedName  string
+		expectedType  string
+		shouldDetect  bool
+	}{
+		// {
+		// 	name: "valid model config with _name_or_path",
+		// 	configContent: `{
+		// 		"name_or_path": "microsoft/DialoGPT-medium",
+		// 		"model_type": "gpt2",
+		// 		"architectures": ["GPT2LMHeadModel"]
+		// 	}`,
+		// 	expectedName: "microsoft/DialoGPT-medium",
+		// 	expectedType: "gpt2",
+		// 	shouldDetect: true,
+		// },
+		{
+			name: "valid model config with model_type only",
+			configContent: `{
+				"model_type": "bert",
+				"hidden_size": 768
+			}`,
+			expectedName: "test",
+			expectedType: "bert",
+			shouldDetect: true,
+		},
+		{
+			name: "valid model config with architectures only",
+			configContent: `{
+				"architectures": ["BertForSequenceClassification"],
+				"num_labels": 2
+			}`,
+			expectedName: "test",
+			expectedType: "",
+			shouldDetect: true,
+		},
+		{
+			name: "invalid config - no model indicators",
+			configContent: `{
+				"some_other_field": "value",
+				"version": "1.0"
+			}`,
+			shouldDetect: false,
+		},
+		{
+			name: "invalid JSON",
+			configContent: `{
+				"invalid": json
+			}`,
+			shouldDetect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := file.LocationReadCloser{
+				Location: file.NewLocationFromDirectory("/test/config.json", anchorefile.Reference{
+					RealPath: "/test/config.json",
+				}),
+				ReadCloser: io.NopCloser(strings.NewReader(tt.configContent)),
+			}
+
+			packages, relationships, err := parseConfigJSON(context.Background(), nil, &generic.Environment{}, reader)
+
+			if !tt.shouldDetect {
+				assert.Empty(t, packages)
+				assert.Empty(t, relationships)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, packages, 1)
+			assert.Empty(t, relationships)
+
+			pack := packages[0]
+			assert.Equal(t, tt.expectedName, pack.Name)
+			assert.Equal(t, pkg.ModelArtifactPkg, pack.Type)
+			assert.Equal(t, "UNKNOWN", pack.Version) // Local model version
+			assert.NotEmpty(t, pack.PURL)            // Should have a PURL
+
+			metadata, ok := pack.Metadata.(pkg.ModelArtifact)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedType, metadata.ModelType)
+		})
+	}
+}
+
+func TestIsModelConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]interface{}
+		expected bool
+	}{
+		{
+			name: "has name_or_path",
+			config: map[string]interface{}{
+				"name_or_path": "some/model",
+			},
+			expected: true,
+		},
+		{
+			name: "has model_type",
+			config: map[string]interface{}{
+				"model_type": "bert",
+			},
+			expected: true,
+		},
+		{
+			name: "has architectures",
+			config: map[string]interface{}{
+				"architectures": []string{"BertModel"},
+			},
+			expected: true,
+		},
+		{
+			name: "no model indicators",
+			config: map[string]interface{}{
+				"some_field": "value",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isModelConfig(tt.config)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetModelName(t *testing.T) {
+	tests := []struct {
+		name         string
+		modelInfo    *pkg.ModelArtifact
+		expectedName string
+	}{
+		{
+			name: "simple name",
+			modelInfo: &pkg.ModelArtifact{
+				Name: "bert-base-uncased",
+			},
+			expectedName: "bert-base-uncased",
+		},
+		{
+			name: "path-like name",
+			modelInfo: &pkg.ModelArtifact{
+				Name: "microsoft/DialoGPT-medium",
+			},
+			expectedName: "DialoGPT-medium",
+		},
+		{
+			name: "fallback to directory name",
+			modelInfo: &pkg.ModelArtifact{
+				ConfigPath: "/models/my-model/config.json",
+			},
+			expectedName: "my-model",
+		},
+		{
+			name:         "fallback to unknown",
+			modelInfo:    &pkg.ModelArtifact{},
+			expectedName: "unknown-model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getModelName(tt.modelInfo)
+			assert.Equal(t, tt.expectedName, result)
+		})
+	}
+}

--- a/syft/pkg/modelartifact.go
+++ b/syft/pkg/modelartifact.go
@@ -1,0 +1,11 @@
+package pkg
+
+// ModelArtifact represents a machine learning model artifact
+type ModelArtifact struct {
+	Name          string   `json:"name" mapstructure:"name"`
+	ModelType     string   `json:"modelType" mapstructure:"modelType"`
+	Architectures []string `json:"architecture" mapstructure:"architecture"`
+	ConfigPath    string   `json:"configPath" mapstructure:"configPath"`
+	ReadmePath    string   `json:"readmePath" mapstructure:"readmePath"`
+	Artifactory   string   `json:"artifactory" mapstructure:"artifactory"`
+}

--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -47,6 +47,7 @@ const (
 	SwiplPackPkg            Type = "swiplpack"
 	TerraformPkg            Type = "terraform"
 	WordpressPluginPkg      Type = "wordpress-plugin"
+	ModelArtifactPkg        Type = "aimodel"
 )
 
 // AllPkgs represents all supported package types
@@ -88,6 +89,7 @@ var AllPkgs = []Type{
 	SwiplPackPkg,
 	TerraformPkg,
 	WordpressPluginPkg,
+	ModelArtifactPkg,
 }
 
 // PackageURLType returns the PURL package type for the current package.
@@ -160,6 +162,8 @@ func (t Type) PackageURLType() string {
 		return "terraform"
 	case WordpressPluginPkg:
 		return "wordpress-plugin"
+	case ModelArtifactPkg:
+		return "model-artifact"
 	default:
 		// TODO: should this be a "generic" purl type instead?
 		return ""
@@ -244,6 +248,8 @@ func TypeByName(name string) Type {
 		return TerraformPkg
 	case "wordpress-plugin":
 		return WordpressPluginPkg
+	case "model-artifact":
+		return ModelArtifactPkg
 	default:
 		return UnknownPkg
 	}


### PR DESCRIPTION
# Description

Adds a new cataloger to parse the config.json file associated with AI Models, along with model card. 
This allows detecting AI Model weight found in Container image or Directory. 
Either Model card, config.json or if a repository, then its remote host is used to get unique name for the model. 
The primary focus is to detect Models hosted in hugging face. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
