### PR TITLE
Use Ubuntu 24.04 in Release GitHub action workflow

### DIFF
--- a/.github/workflows/release-lineaje.yaml
+++ b/.github/workflows/release-lineaje.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   quality-gate:
     environment: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
@@ -82,7 +82,7 @@ jobs:
 
   release:
     needs: [quality-gate]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
Use Ubuntu 24.04 in Release GitHub action workflow as 20.04 has been deprecated