### PR TITLE
Detect huggingface repository in Containers

### DIFF
--- a/syft/pkg/cataloger/modelartifact/parse_config_test.go
+++ b/syft/pkg/cataloger/modelartifact/parse_config_test.go
@@ -25,7 +25,7 @@ func TestParseConfigJSON(t *testing.T) {
 		{
 			name: "valid model config with _name_or_path",
 			configContent: `{
-				"name_or_path": "microsoft/DialoGPT-medium",
+				"_name_or_path": "microsoft/DialoGPT-medium",
 				"model_type": "gpt2",
 				"architectures": ["GPT2LMHeadModel"]
 			}`,
@@ -111,9 +111,9 @@ func TestIsModelConfig(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "has name_or_path",
+			name: "has _name_or_path",
 			config: map[string]interface{}{
-				"name_or_path": "some/model",
+				"_name_or_path": "some/model",
 			},
 			expected: true,
 		},


### PR DESCRIPTION
The PR fixes following issue
1. The huggingface tranformer.PretrainedConfig implementation has _name_or_path variable
e.g. https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2/blob/main/config.json
The documentation(https://huggingface.co/docs/transformers/main_classes/configuration) had name_or_path required, thus, earlier implementation had the key. But the key was not found in any model config file.  

2. The .git files should be read using file resolver to get content from container's layer

3. The default version for huggingface base model should be main


## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [*] I have added unit tests that cover changed behavior
- [*] I have tested my code in common scenarios and confirmed there are no regressions
- [*] I have added comments to my code, particularly in hard-to-understand sections
